### PR TITLE
Fixing build command for Windows users

### DIFF
--- a/Commands/IcedCoffeeScript.sublime-build
+++ b/Commands/IcedCoffeeScript.sublime-build
@@ -2,5 +2,10 @@
 	"path": "$HOME/bin:/usr/local/bin:$PATH",
 	"cmd": ["iced","-c","$file"],
 	"file_regex": "^(...*?):([0-9]*):?([0-9]*)",
-	"selector": "source.coffee"
+	"selector": "source.coffee",
+
+	"windows":
+	{
+		"cmd": ["iced.cmd", "-c", "$file"]
+	}
 }


### PR DESCRIPTION
For some of us with Sublime Text on Windows, not having "cmd" on the end
of the command (`iced.cmd` instead of `iced`) means the command fails
even if `iced` is installed through npm and available globally; e.g.
through PowerShell or CMD.
Using the Windows-specific selector we can override this for all Windows users without affecting other users. :smile: 
